### PR TITLE
Slightly extend inigo's changes for supervised baseline

### DIFF
--- a/galaxy_datasets/shared/label_metadata.py
+++ b/galaxy_datasets/shared/label_metadata.py
@@ -395,32 +395,36 @@ ukidss_ortho_dependencies = {
 
 
 
-def get_gz_evo_v1_metadata():
+def get_gz_evo_v1_metadata(internal):
 
     question_answer_pairs = {}
     question_answer_pairs.update(decals_all_campaigns_ortho_pairs)
     question_answer_pairs.update(gz2_ortho_pairs)
     question_answer_pairs.update(candels_ortho_pairs)
     question_answer_pairs.update(hubble_ortho_pairs)
-    question_answer_pairs.update(cosmic_dawn_ortho_pairs)
+    if internal:
+        question_answer_pairs.update(cosmic_dawn_ortho_pairs)
 
     dependencies = {}
     dependencies.update(decals_ortho_dependencies)
     dependencies.update(gz2_ortho_dependencies)
     dependencies.update(candels_ortho_dependencies)
     dependencies.update(hubble_ortho_dependencies)
-    dependencies.update(cosmic_dawn_ortho_dependencies)
+    if internal:
+        dependencies.update(cosmic_dawn_ortho_dependencies)
 
     label_cols = \
         decals_all_campaigns_ortho_label_cols + \
         gz2_ortho_label_cols + \
         candels_ortho_label_cols + \
-        hubble_ortho_label_cols + \
-        cosmic_dawn_ortho_label_cols
+        hubble_ortho_label_cols
+    if internal:
+        label_cols += cosmic_dawn_ortho_label_cols
 
     return label_cols, question_answer_pairs, dependencies
 
-gz_evo_v1_label_cols, gz_evo_v1_pairs, gz_evo_v1_dependencies = get_gz_evo_v1_metadata()
+gz_evo_v1_label_cols, gz_evo_v1_pairs, gz_evo_v1_dependencies = get_gz_evo_v1_metadata(internal=True)
+gz_evo_v1_public_label_cols, gz_evo_v1_public_pairs, gz_evo_v1_public_dependencies = get_gz_evo_v1_metadata(internal=False)
 
 
 jwst_ortho_pairs = {

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="galaxy-datasets",
-    version="0.0.18",
+    version="0.0.19",
     author="Mike Walmsley",
     author_email="walmsleymk1@gmail.com",
     description="Galaxy Zoo datasets for PyTorch/TensorFlow",
@@ -20,12 +20,13 @@ setuptools.setup(
         "Environment :: GPU :: NVIDIA CUDA"
     ],
     packages=setuptools.find_packages(),
-    python_requires=">=3.7",  # zoobot has 3.8,
+    python_requires=">=3.9",  # zoobot has 3.9,
     install_requires=[
         'numpy',
         'pandas',
         'pyarrow',
-        'requests'
+        'requests',
+        'datasets'  # for HF typing
     ],
     extras_require={
         # these are lower than zoobot's reqs
@@ -33,11 +34,10 @@ setuptools.setup(
             'torch >= 1.10.1',
             'torchvision >= 0.11.2',
             'torchaudio >= 0.10.1',
-            'pytorch-lightning >=1.6.5',  # 1.7 requires protobuf version incompatible with tensorflow/tensorboard. Otherwise works.
-            # 'simplejpeg',
-            'albumentations'
+            'pytorch-lightning >=2.0',
+            'albumentations'  # torchvision now preferred
         ],
-        'tensorflow': [
+        'tensorflow': [ # will be deprecated
             'tensorflow >= 2.10.0',
             'protobuf <= 3.19'  # tensorflow incompatible above this (usually resolved by pip automatically)
         ]


### PR DESCRIPTION
- If no val split, create from splitting train dataset not by using test dataset
- inherit from GalaxyDataModule
- GalaxyDataset expects `label_cols` list (default ['label']) to support Zoobot's complicated label lists
- `target_transform` acts on all of `example`, similarly